### PR TITLE
Add constants in export

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The versioning is divided in two groups, separated with "-" (hyphen). The first 
 
 Library is prepared to work with [JS Promises](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Promise), so you should use them or [Async/Await](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Sentencias/funcion_asincrona)
 ````javascript
-const TestLink = require('testlink-xmlrpc');
+const {TestLink, constants} = require('testlink-xmlrpc');
 
 let testlink = new TestLink({
     host: "testlink.my-server.com",

--- a/index.js
+++ b/index.js
@@ -18,4 +18,5 @@
  * @author Luis Zurro de Cos <luiszurrodecos@gmail.com
  */
 
-exports = module.exports = require('./lib/testlink');
+module.exports.TestLink = require('./lib/testlink');
+module.exports.constants = require('./lib/constants');


### PR DESCRIPTION
Please. add this change to use the constants in the import of the library, the import will be:

const {TestLink, constants} = require('testlink-xmlrpc');

And we will use the constants, for example:

constants.ExecutionStatus.PASSED