### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 # Controls when the action will run.
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Nyaran/testlink-xmlrpc/security/code-scanning/5](https://github.com/Nyaran/testlink-xmlrpc/security/code-scanning/5)

To address the problem, add a `permissions` block either at the workflow level (near the top of the file, affecting all jobs), or specifically within the `build` job definition. The minimal starting point should be `contents: read`, which gives read-only access to repository contents—sufficient for the tasks demonstrated (checkout, test, coverage upload, etc.). Doing this reduces the risk surface for the workflow by preventing unwanted write capability via GITHUB_TOKEN. Given only one job is present and there isn’t an existing workflow-level permissions block, the best fix is to add it just after the workflow’s `name`, or before the `jobs:` block for the broadest effect.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
