### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -19,6 +19,9 @@ on:
         required: false
         default: true
 
+permissions:
+  contents: read
+  pull-requests: write
 env:
   GIT_USER_NAME: 'Luis Zurro de Cos'
   GIT_USER_EMAIL: '1042532+Nyaran@users.noreply.github.com'


### PR DESCRIPTION
Potential fix for [https://github.com/Nyaran/testlink-xmlrpc/security/code-scanning/3](https://github.com/Nyaran/testlink-xmlrpc/security/code-scanning/3)

To fix this problem, you should add a `permissions:` block to the workflow, specifying the minimal `contents: read` and `pull-requests: write` permissions, which are the least privileges required by this workflow. The `actions/checkout` step needs `contents: read`, and `peter-evans/create-pull-request` needs `pull-requests: write`. The optimal place to do this is at the workflow root (before `env:` for global application), so all jobs will inherit this minimal set unless overridden. Edit the `.github/workflows/create-release-pr.yml` file and add the following block after `name:` (before `env:`):

```yaml
permissions:
  contents: read
  pull-requests: write
```
No other code changes or extra dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
