### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     if:  startsWith(github.head_ref, 'release/')
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Nyaran/testlink-xmlrpc/security/code-scanning/2](https://github.com/Nyaran/testlink-xmlrpc/security/code-scanning/2)

To fix the problem, the workflow should add a `permissions` block with the appropriate permissions required for the workflow/job to run. Since the `softprops/action-gh-release` action creates a GitHub release, it requires `contents: write` permission. It is recommended to set this permission at the job-level (to keep the scope tight), but can also be added at the root if all jobs require the same permission. The fix here is to add the following block under the `release:` job:

```yaml
permissions:
  contents: write
```

This should be added directly under `release:` and above `runs-on: ubuntu-latest` (after line 10, before line 11). No imports or further dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
