### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,4 +1,6 @@
 name: Publish Release
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Nyaran/testlink-xmlrpc/security/code-scanning/1](https://github.com/Nyaran/testlink-xmlrpc/security/code-scanning/1)

To fix this issue, add a `permissions` block at the job level (inside the `publish` job) or at the workflow root (top-level) to restrict the GITHUB_TOKEN to only the necessary scopes for this workflow. Since this workflow is publishing an npm package but does not push, open PRs, or write to the repository, it only requires read access to repository contents for actions/checkout and similar purposes. The best way to fix is to add:

```yaml
permissions:
  contents: read
```

either at the workflow top (line 2, after name:) or directly under the `publish` job (after line 8). Both approaches are fine, but per the CodeQL recommendation, a minimal default should be set. If some jobs needed additional privileges they'd add their own block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
